### PR TITLE
allow to pass main title to 'plot' functions + fix notes from R CMD check

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: mlmm
 Title: An efficient multi-locus mixed-model approach for genome-wide association
     studies in structured populations
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: c(
     person("Vincent", "Segura", email="vincent.segura@orleans.inra.fr", role=c("aut")),
     person("Bjarni J.", "Vilhjalmsson", email="bjvl@birc.au.dk", role=c("aut")),
@@ -27,4 +27,4 @@ Suggests:
     knitr,
     rmarkdown
 VignetteBuilder: knitr
-RoxygenNote: 5.0.1
+RoxygenNote: 6.0.1

--- a/R/mlmm.r
+++ b/R/mlmm.r
@@ -151,24 +151,24 @@ mlmm <- function(Y,X,K,nbchunks,maxsteps,thresh = NULL) {
   M<-solve(chol(mod_fwd[[1]]$vg*K_norm+mod_fwd[[1]]$ve*diag(n)))
   Y_t<-crossprod(M,Y)
   cof_fwd_t<-crossprod(M,cof_fwd[[1]])
-  fwd_lm[[1]]<-summary(lm(Y_t~0+cof_fwd_t))
+  fwd_lm[[1]]<-summary(stats::lm(Y_t~0+cof_fwd_t))
   Res_H0<-fwd_lm[[1]]$residuals
   Q_<-qr.Q(qr(cof_fwd_t))
 
   RSS<-list()
   for (j in 1:(nbchunks-1)) {
     X_t<-crossprod(M %*% (diag(n)-tcrossprod(Q_,Q_)),(X[,!colnames(X) %in% colnames(cof_fwd[[1]])])[,((j-1)*round(m/nbchunks)+1):(j*round(m/nbchunks))])
-    RSS[[j]]<-apply(X_t,2,function(x){sum(lsfit(x,Res_H0,intercept = FALSE)$residuals^2)})
+    RSS[[j]]<-apply(X_t,2,function(x){sum(stats::lsfit(x,Res_H0,intercept = FALSE)$residuals^2)})
     rm(X_t)}
   X_t<-crossprod(M %*% (diag(n)-tcrossprod(Q_,Q_)),(X[,!colnames(X) %in% colnames(cof_fwd[[1]])])[,((j)*round(m/nbchunks)+1):(m-(ncol(cof_fwd[[1]])-1))])
-  RSS[[nbchunks]]<-apply(X_t,2,function(x){sum(lsfit(x,Res_H0,intercept = FALSE)$residuals^2)})
+  RSS[[nbchunks]]<-apply(X_t,2,function(x){sum(stats::lsfit(x,Res_H0,intercept = FALSE)$residuals^2)})
   rm(X_t,j)
 
   RSSf[[2]]<-unlist(RSS)
   RSS_H0[[2]]<-sum(Res_H0^2)
   df2[[2]]<-n-df1-ncol(cof_fwd[[1]])
   Ftest[[2]]<-(rep(RSS_H0[[2]],length(RSSf[[2]]))/RSSf[[2]]-1)*df2[[2]]/df1
-  pval[[2]]<-pf(Ftest[[2]],df1,df2[[2]],lower.tail=FALSE)
+  pval[[2]]<-stats::pf(Ftest[[2]],df1,df2[[2]],lower.tail=FALSE)
 
   cof_fwd[[2]]<-cbind(cof_fwd[[1]],X[,colnames(X) %in% names(which(RSSf[[2]]==min(RSSf[[2]]))[1])])
   colnames(cof_fwd[[2]])<-c(colnames(cof_fwd[[1]]),names(which(RSSf[[2]]==min(RSSf[[2]]))[1]))
@@ -188,24 +188,24 @@ mlmm <- function(Y,X,K,nbchunks,maxsteps,thresh = NULL) {
       M<-solve(chol(mod_fwd[[i-1]]$vg*K_norm+mod_fwd[[i-1]]$ve*diag(n)))
       Y_t<-crossprod(M,Y)
       cof_fwd_t<-crossprod(M,cof_fwd[[i-1]])
-      fwd_lm[[i-1]]<-summary(lm(Y_t~0+cof_fwd_t))
+      fwd_lm[[i-1]]<-summary(stats::lm(Y_t~0+cof_fwd_t))
       Res_H0<-fwd_lm[[i-1]]$residuals
       Q_ <- qr.Q(qr(cof_fwd_t))
 
       RSS<-list()
       for (j in 1:(nbchunks-1)) {
         X_t<-crossprod(M %*% (diag(n)-tcrossprod(Q_,Q_)),(X[,!colnames(X) %in% colnames(cof_fwd[[i-1]])])[,((j-1)*round(m/nbchunks)+1):(j*round(m/nbchunks))])
-        RSS[[j]]<-apply(X_t,2,function(x){sum(lsfit(x,Res_H0,intercept = FALSE)$residuals^2)})
+        RSS[[j]]<-apply(X_t,2,function(x){sum(stats::lsfit(x,Res_H0,intercept = FALSE)$residuals^2)})
         rm(X_t)}
       X_t<-crossprod(M %*% (diag(n)-tcrossprod(Q_,Q_)),(X[,!colnames(X) %in% colnames(cof_fwd[[i-1]])])[,((j)*round(m/nbchunks)+1):(m-(ncol(cof_fwd[[i-1]])-1))])
-      RSS[[nbchunks]]<-apply(X_t,2,function(x){sum(lsfit(x,Res_H0,intercept = FALSE)$residuals^2)})
+      RSS[[nbchunks]]<-apply(X_t,2,function(x){sum(stats::lsfit(x,Res_H0,intercept = FALSE)$residuals^2)})
       rm(X_t,j)
 
       RSSf[[i]]<-unlist(RSS)
       RSS_H0[[i]]<-sum(Res_H0^2)
       df2[[i]]<-n-df1-ncol(cof_fwd[[i-1]])
       Ftest[[i]]<-(rep(RSS_H0[[i]],length(RSSf[[i]]))/RSSf[[i]]-1)*df2[[i]]/df1
-      pval[[i]]<-pf(Ftest[[i]],df1,df2[[i]],lower.tail=FALSE)
+      pval[[i]]<-stats::pf(Ftest[[i]],df1,df2[[i]],lower.tail=FALSE)
 
       cof_fwd[[i]]<-cbind(cof_fwd[[i-1]],X[,colnames(X) %in% names(which(RSSf[[i]]==min(RSSf[[i]]))[1])])
       colnames(cof_fwd[[i]])<-c(colnames(cof_fwd[[i-1]]),names(which(RSSf[[i]]==min(RSSf[[i]]))[1]))
@@ -219,7 +219,7 @@ mlmm <- function(Y,X,K,nbchunks,maxsteps,thresh = NULL) {
   M<-solve(chol(mod_fwd[[length(mod_fwd)]]$vg*K_norm+mod_fwd[[length(mod_fwd)]]$ve*diag(n)))
   Y_t<-crossprod(M,Y)
   cof_fwd_t<-crossprod(M,cof_fwd[[length(mod_fwd)]])
-  fwd_lm[[length(mod_fwd)]]<-summary(lm(Y_t~0+cof_fwd_t))
+  fwd_lm[[length(mod_fwd)]]<-summary(stats::lm(Y_t~0+cof_fwd_t))
 
   Res_H0<-fwd_lm[[length(mod_fwd)]]$residuals
   Q_ <- qr.Q(qr(cof_fwd_t))
@@ -227,17 +227,17 @@ mlmm <- function(Y,X,K,nbchunks,maxsteps,thresh = NULL) {
   RSS<-list()
   for (j in 1:(nbchunks-1)) {
     X_t<-crossprod(M %*% (diag(n)-tcrossprod(Q_,Q_)),(X[,!colnames(X) %in% colnames(cof_fwd[[length(mod_fwd)]])])[,((j-1)*round(m/nbchunks)+1):(j*round(m/nbchunks))])
-    RSS[[j]]<-apply(X_t,2,function(x){sum(lsfit(x,Res_H0,intercept = FALSE)$residuals^2)})
+    RSS[[j]]<-apply(X_t,2,function(x){sum(stats::lsfit(x,Res_H0,intercept = FALSE)$residuals^2)})
     rm(X_t)}
   X_t<-crossprod(M %*% (diag(n)-tcrossprod(Q_,Q_)),(X[,!colnames(X) %in% colnames(cof_fwd[[length(mod_fwd)]])])[,((j)*round(m/nbchunks)+1):(m-(ncol(cof_fwd[[length(mod_fwd)]])-1))])
-  RSS[[nbchunks]]<-apply(X_t,2,function(x){sum(lsfit(x,Res_H0,intercept = FALSE)$residuals^2)})
+  RSS[[nbchunks]]<-apply(X_t,2,function(x){sum(stats::lsfit(x,Res_H0,intercept = FALSE)$residuals^2)})
   rm(X_t,j)
 
   RSSf[[length(mod_fwd)+1]]<-unlist(RSS)
   RSS_H0[[length(mod_fwd)+1]]<-sum(Res_H0^2)
   df2[[length(mod_fwd)+1]]<-n-df1-ncol(cof_fwd[[length(mod_fwd)]])
   Ftest[[length(mod_fwd)+1]]<-(rep(RSS_H0[[length(mod_fwd)+1]],length(RSSf[[length(mod_fwd)+1]]))/RSSf[[length(mod_fwd)+1]]-1)*df2[[length(mod_fwd)+1]]/df1
-  pval[[length(mod_fwd)+1]]<-pf(Ftest[[length(mod_fwd)+1]],df1,df2[[length(mod_fwd)+1]],lower.tail=FALSE)
+  pval[[length(mod_fwd)+1]]<-stats::pf(Ftest[[length(mod_fwd)+1]],df1,df2[[length(mod_fwd)+1]],lower.tail=FALSE)
   rm(M,Y_t,cof_fwd_t,Res_H0,Q_,RSS)
 
   ##get max pval at each forward step
@@ -270,7 +270,7 @@ mlmm <- function(Y,X,K,nbchunks,maxsteps,thresh = NULL) {
   M<-solve(chol(mod_bwd[[1]]$vg*K_norm+mod_bwd[[1]]$ve*diag(n)))
   Y_t<-crossprod(M,Y)
   cof_bwd_t<-crossprod(M,cof_bwd[[1]])
-  bwd_lm[[1]]<-summary(lm(Y_t~0+cof_bwd_t))
+  bwd_lm[[1]]<-summary(stats::lm(Y_t~0+cof_bwd_t))
 
   rm(M,Y_t,cof_bwd_t)
 
@@ -283,7 +283,7 @@ mlmm <- function(Y,X,K,nbchunks,maxsteps,thresh = NULL) {
     M<-solve(chol(mod_bwd[[i]]$vg*K_norm+mod_bwd[[i]]$ve*diag(n)))
     Y_t<-crossprod(M,Y)
     cof_bwd_t<-crossprod(M,cof_bwd[[i]])
-    bwd_lm[[i]]<-summary(lm(Y_t~0+cof_bwd_t))
+    bwd_lm[[i]]<-summary(stats::lm(Y_t~0+cof_bwd_t))
     rm(M,Y_t,cof_bwd_t)}
 
   rm(i)
@@ -358,22 +358,22 @@ mlmm <- function(Y,X,K,nbchunks,maxsteps,thresh = NULL) {
       M<-solve(chol(mixedmod$vg*K_norm+mixedmod$ve*diag(n)))
       Y_t<-crossprod(M,Y)
       cof_t<-crossprod(M,cof)
-      GLS_lm<-summary(lm(Y_t~0+cof_t))
+      GLS_lm<-summary(stats::lm(Y_t~0+cof_t))
       Res_H0<-GLS_lm$residuals
       Q_ <- qr.Q(qr(cof_t))
       RSS<-list()
       for (j in 1:(nbchunks-1)) {
         X_t<-crossprod(M %*% (diag(n)-tcrossprod(Q_,Q_)),(X[,!colnames(X) %in% colnames(cof)])[,((j-1)*round(m/nbchunks)+1):(j*round(m/nbchunks))])
-        RSS[[j]]<-apply(X_t,2,function(x){sum(lsfit(x,Res_H0,intercept = FALSE)$residuals^2)})
+        RSS[[j]]<-apply(X_t,2,function(x){sum(stats::lsfit(x,Res_H0,intercept = FALSE)$residuals^2)})
         rm(X_t)}
       X_t<-crossprod(M %*% (diag(n)-tcrossprod(Q_,Q_)),(X[,!colnames(X) %in% colnames(cof)])[,((j)*round(m/nbchunks)+1):(m-(ncol(cof)-1))])
-      RSS[[nbchunks]]<-apply(X_t,2,function(x){sum(lsfit(x,Res_H0,intercept = FALSE)$residuals^2)})
+      RSS[[nbchunks]]<-apply(X_t,2,function(x){sum(stats::lsfit(x,Res_H0,intercept = FALSE)$residuals^2)})
       rm(X_t,j)
       RSSf<-unlist(RSS)
       RSS_H0<-sum(Res_H0^2)
       df2<-n-df1-ncol(cof)
       Ftest<-(rep(RSS_H0,length(RSSf))/RSSf-1)*df2/df1
-      pval<-pf(Ftest,df1,df2,lower.tail=FALSE)
+      pval<-stats::pf(Ftest,df1,df2,lower.tail=FALSE)
       list('out'=rbind(data.frame(SNP=colnames(cof)[-1],'pval'=GLS_lm$coef[2:(ncol(cof)),4]),
                        data.frame('SNP'=colnames(X)[-which(colnames(X) %in% colnames(cof))],'pval'=pval)),
            'cof'=colnames(cof)[-1],

--- a/R/mlmm_cof.r
+++ b/R/mlmm_cof.r
@@ -160,24 +160,24 @@ mlmm_cof<-function(Y,X,cofs,K,nbchunks,maxsteps,thresh = NULL) {
   M<-solve(chol(mod_fwd[[1]]$vg*K_norm+mod_fwd[[1]]$ve*diag(n)))
   Y_t<-crossprod(M,Y)
   cof_fwd_t<-crossprod(M,cbind(fix_cofs,cof_fwd[[1]]))
-  fwd_lm[[1]]<-summary(lm(Y_t~0+cof_fwd_t))
+  fwd_lm[[1]]<-summary(stats::lm(Y_t~0+cof_fwd_t))
   Res_H0<-fwd_lm[[1]]$residuals
   Q_<-qr.Q(qr(cof_fwd_t))
 
   RSS<-list()
   for (j in 1:(nbchunks-1)) {
     X_t<-crossprod(M %*% (diag(n)-tcrossprod(Q_,Q_)),(X[,!colnames(X) %in% addcof_fwd[[1]]])[,((j-1)*round(m/nbchunks)+1):(j*round(m/nbchunks))])
-    RSS[[j]]<-apply(X_t,2,function(x){sum(lsfit(x,Res_H0,intercept = FALSE)$residuals^2)})
+    RSS[[j]]<-apply(X_t,2,function(x){sum(stats::lsfit(x,Res_H0,intercept = FALSE)$residuals^2)})
     rm(X_t)}
   X_t<-crossprod(M %*% (diag(n)-tcrossprod(Q_,Q_)),(X[,!colnames(X) %in% addcof_fwd[[1]]])[,((j)*round(m/nbchunks)+1):(m-(ncol(cof_fwd[[1]])))])
-  RSS[[nbchunks]]<-apply(X_t,2,function(x){sum(lsfit(x,Res_H0,intercept = FALSE)$residuals^2)})
+  RSS[[nbchunks]]<-apply(X_t,2,function(x){sum(stats::lsfit(x,Res_H0,intercept = FALSE)$residuals^2)})
   rm(X_t,j)
 
   RSSf[[2]]<-unlist(RSS)
   RSS_H0[[2]]<-sum(Res_H0^2)
   df2[[2]]<-n-df1-ncol(fix_cofs)-ncol(cof_fwd[[1]])
   Ftest[[2]]<-(rep(RSS_H0[[2]],length(RSSf[[2]]))/RSSf[[2]]-1)*df2[[2]]/df1
-  pval[[2]]<-pf(Ftest[[2]],df1,df2[[2]],lower.tail=FALSE)
+  pval[[2]]<-stats::pf(Ftest[[2]],df1,df2[[2]],lower.tail=FALSE)
   addcof_fwd[[2]]<-names(which(RSSf[[2]]==min(RSSf[[2]]))[1])
   cof_fwd[[2]]<-cbind(cof_fwd[[1]],X[,colnames(X) %in% addcof_fwd[[2]]])
   colnames(cof_fwd[[2]])[ncol(cof_fwd[[2]])]<-addcof_fwd[[2]]
@@ -197,24 +197,24 @@ mlmm_cof<-function(Y,X,cofs,K,nbchunks,maxsteps,thresh = NULL) {
       M<-solve(chol(mod_fwd[[i-1]]$vg*K_norm+mod_fwd[[i-1]]$ve*diag(n)))
       Y_t<-crossprod(M,Y)
       cof_fwd_t<-crossprod(M,cbind(fix_cofs,cof_fwd[[i-1]]))
-      fwd_lm[[i-1]]<-summary(lm(Y_t~0+cof_fwd_t))
+      fwd_lm[[i-1]]<-summary(stats::lm(Y_t~0+cof_fwd_t))
       Res_H0<-fwd_lm[[i-1]]$residuals
       Q_ <- qr.Q(qr(cof_fwd_t))
 
       RSS<-list()
       for (j in 1:(nbchunks-1)) {
         X_t<-crossprod(M %*% (diag(n)-tcrossprod(Q_,Q_)),(X[,!colnames(X) %in% colnames(cof_fwd[[i-1]])])[,((j-1)*round(m/nbchunks)+1):(j*round(m/nbchunks))])
-        RSS[[j]]<-apply(X_t,2,function(x){sum(lsfit(x,Res_H0,intercept = FALSE)$residuals^2)})
+        RSS[[j]]<-apply(X_t,2,function(x){sum(stats::lsfit(x,Res_H0,intercept = FALSE)$residuals^2)})
         rm(X_t)}
       X_t<-crossprod(M %*% (diag(n)-tcrossprod(Q_,Q_)),(X[,!colnames(X) %in% colnames(cof_fwd[[i-1]])])[,((j)*round(m/nbchunks)+1):(m-(ncol(cof_fwd[[i-1]])))])
-      RSS[[nbchunks]]<-apply(X_t,2,function(x){sum(lsfit(x,Res_H0,intercept = FALSE)$residuals^2)})
+      RSS[[nbchunks]]<-apply(X_t,2,function(x){sum(stats::lsfit(x,Res_H0,intercept = FALSE)$residuals^2)})
       rm(X_t,j)
 
       RSSf[[i]]<-unlist(RSS)
       RSS_H0[[i]]<-sum(Res_H0^2)
       df2[[i]]<-n-df1-ncol(fix_cofs)-ncol(cof_fwd[[i-1]])
       Ftest[[i]]<-(rep(RSS_H0[[i]],length(RSSf[[i]]))/RSSf[[i]]-1)*df2[[i]]/df1
-      pval[[i]]<-pf(Ftest[[i]],df1,df2[[i]],lower.tail=FALSE)
+      pval[[i]]<-stats::pf(Ftest[[i]],df1,df2[[i]],lower.tail=FALSE)
       addcof_fwd[[i]]<-names(which(RSSf[[i]]==min(RSSf[[i]]))[1])
       cof_fwd[[i]]<-cbind(cof_fwd[[i-1]],X[,colnames(X) %in% addcof_fwd[[i]]])
       colnames(cof_fwd[[i]])[ncol(cof_fwd[[i]])]<-addcof_fwd[[i]]
@@ -228,7 +228,7 @@ mlmm_cof<-function(Y,X,cofs,K,nbchunks,maxsteps,thresh = NULL) {
   M<-solve(chol(mod_fwd[[length(mod_fwd)]]$vg*K_norm+mod_fwd[[length(mod_fwd)]]$ve*diag(n)))
   Y_t<-crossprod(M,Y)
   cof_fwd_t<-crossprod(M,cbind(fix_cofs,cof_fwd[[length(mod_fwd)]]))
-  fwd_lm[[length(mod_fwd)]]<-summary(lm(Y_t~0+cof_fwd_t))
+  fwd_lm[[length(mod_fwd)]]<-summary(stats::lm(Y_t~0+cof_fwd_t))
 
   Res_H0<-fwd_lm[[length(mod_fwd)]]$residuals
   Q_ <- qr.Q(qr(cof_fwd_t))
@@ -236,17 +236,17 @@ mlmm_cof<-function(Y,X,cofs,K,nbchunks,maxsteps,thresh = NULL) {
   RSS<-list()
   for (j in 1:(nbchunks-1)) {
     X_t<-crossprod(M %*% (diag(n)-tcrossprod(Q_,Q_)),(X[,!colnames(X) %in% colnames(cof_fwd[[length(mod_fwd)]])])[,((j-1)*round(m/nbchunks)+1):(j*round(m/nbchunks))])
-    RSS[[j]]<-apply(X_t,2,function(x){sum(lsfit(x,Res_H0,intercept = FALSE)$residuals^2)})
+    RSS[[j]]<-apply(X_t,2,function(x){sum(stats::lsfit(x,Res_H0,intercept = FALSE)$residuals^2)})
     rm(X_t)}
   X_t<-crossprod(M %*% (diag(n)-tcrossprod(Q_,Q_)),(X[,!colnames(X) %in% colnames(cof_fwd[[length(mod_fwd)]])])[,((j)*round(m/nbchunks)+1):(m-(ncol(cof_fwd[[length(mod_fwd)]])))])
-  RSS[[nbchunks]]<-apply(X_t,2,function(x){sum(lsfit(x,Res_H0,intercept = FALSE)$residuals^2)})
+  RSS[[nbchunks]]<-apply(X_t,2,function(x){sum(stats::lsfit(x,Res_H0,intercept = FALSE)$residuals^2)})
   rm(X_t,j)
 
   RSSf[[length(mod_fwd)+1]]<-unlist(RSS)
   RSS_H0[[length(mod_fwd)+1]]<-sum(Res_H0^2)
   df2[[length(mod_fwd)+1]]<-n-df1-ncol(fix_cofs)-ncol(cof_fwd[[length(mod_fwd)]])
   Ftest[[length(mod_fwd)+1]]<-(rep(RSS_H0[[length(mod_fwd)+1]],length(RSSf[[length(mod_fwd)+1]]))/RSSf[[length(mod_fwd)+1]]-1)*df2[[length(mod_fwd)+1]]/df1
-  pval[[length(mod_fwd)+1]]<-pf(Ftest[[length(mod_fwd)+1]],df1,df2[[length(mod_fwd)+1]],lower.tail=FALSE)
+  pval[[length(mod_fwd)+1]]<-stats::pf(Ftest[[length(mod_fwd)+1]],df1,df2[[length(mod_fwd)+1]],lower.tail=FALSE)
   rm(M,Y_t,cof_fwd_t,Res_H0,Q_,RSS)
 
   ##get max pval at each forward step
@@ -279,7 +279,7 @@ mlmm_cof<-function(Y,X,cofs,K,nbchunks,maxsteps,thresh = NULL) {
   M<-solve(chol(mod_bwd[[1]]$vg*K_norm+mod_bwd[[1]]$ve*diag(n)))
   Y_t<-crossprod(M,Y)
   cof_bwd_t<-crossprod(M,cbind(fix_cofs,cof_bwd[[1]]))
-  bwd_lm[[1]]<-summary(lm(Y_t~0+cof_bwd_t))
+  bwd_lm[[1]]<-summary(stats::lm(Y_t~0+cof_bwd_t))
 
   rm(M,Y_t,cof_bwd_t)
 
@@ -293,7 +293,7 @@ mlmm_cof<-function(Y,X,cofs,K,nbchunks,maxsteps,thresh = NULL) {
     M<-solve(chol(mod_bwd[[i]]$vg*K_norm+mod_bwd[[i]]$ve*diag(n)))
     Y_t<-crossprod(M,Y)
     cof_bwd_t<-crossprod(M,cbind(fix_cofs,cof_bwd[[i]]))
-    bwd_lm[[i]]<-summary(lm(Y_t~0+cof_bwd_t))
+    bwd_lm[[i]]<-summary(stats::lm(Y_t~0+cof_bwd_t))
     rm(M,Y_t,cof_bwd_t)}
 
   rm(i)
@@ -341,7 +341,7 @@ mlmm_cof<-function(Y,X,cofs,K,nbchunks,maxsteps,thresh = NULL) {
   M<-solve(chol(null$vg*K_norm+null$ve*diag(n)))
   Y_t<-crossprod(M,Y)
   Xo_t<-crossprod(M,as.matrix(Xo))
-  null_lm<-summary(lm(Y_t~0+Xo_t))
+  null_lm<-summary(stats::lm(Y_t~0+Xo_t))
   rm(null,M,Y_t,Xo_t)
   RSS_null<-sum((Y-as.matrix(Xo)%*%null_lm$coef[,1])^2)
 
@@ -385,22 +385,22 @@ mlmm_cof<-function(Y,X,cofs,K,nbchunks,maxsteps,thresh = NULL) {
       M<-solve(chol(mixedmod$vg*K_norm+mixedmod$ve*diag(n)))
       Y_t<-crossprod(M,Y)
       cof_t<-crossprod(M,cbind(fix_cofs,cof))
-      GLS_lm<-summary(lm(Y_t~0+cof_t))
+      GLS_lm<-summary(stats::lm(Y_t~0+cof_t))
       Res_H0<-GLS_lm$residuals
       Q_ <- qr.Q(qr(cof_t))
       RSS<-list()
       for (j in 1:(nbchunks-1)) {
         X_t<-crossprod(M %*% (diag(n)-tcrossprod(Q_,Q_)),(X[,!colnames(X) %in% colnames(cof)])[,((j-1)*round(m/nbchunks)+1):(j*round(m/nbchunks))])
-        RSS[[j]]<-apply(X_t,2,function(x){sum(lsfit(x,Res_H0,intercept = FALSE)$residuals^2)})
+        RSS[[j]]<-apply(X_t,2,function(x){sum(stats::lsfit(x,Res_H0,intercept = FALSE)$residuals^2)})
         rm(X_t)}
       X_t<-crossprod(M %*% (diag(n)-tcrossprod(Q_,Q_)),(X[,!colnames(X) %in% colnames(cof)])[,((j)*round(m/nbchunks)+1):(m-ncol(cof))])
-      RSS[[nbchunks]]<-apply(X_t,2,function(x){sum(lsfit(x,Res_H0,intercept = FALSE)$residuals^2)})
+      RSS[[nbchunks]]<-apply(X_t,2,function(x){sum(stats::lsfit(x,Res_H0,intercept = FALSE)$residuals^2)})
       rm(X_t,j)
       RSSf<-unlist(RSS)
       RSS_H0<-sum(Res_H0^2)
       df2<-n-df1-ncol(fix_cofs)-ncol(cof)
       Ftest<-(rep(RSS_H0,length(RSSf))/RSSf-1)*df2/df1
-      pval<-pf(Ftest,df1,df2,lower.tail=FALSE)
+      pval<-stats::pf(Ftest,df1,df2,lower.tail=FALSE)
       list('out'=rbind(data.frame(SNP=colnames(cof),'pval'=GLS_lm$coef[(ncol(fix_cofs)+1):(ncol(fix_cofs)+ncol(cof)),4]),
                        data.frame('SNP'=names(pval),'pval'=pval)),
            'cof'=colnames(cof),

--- a/R/plot_mlmm.r
+++ b/R/plot_mlmm.r
@@ -7,15 +7,15 @@
 ##' @author V. Segura & B. J. Vilhjalmsson
 ##' @export
 plot_step_table<-function(x,type,...){
-  if (type=='h2') {graphics::plot(x$step_table$step,x$step_table$h2,type='b',lty=2,pch=20,col='darkblue',xlab='step',ylab='h2')
+  if (type=='h2') {graphics::plot(x$step_table$step,x$step_table$h2,type='b',lty=2,pch=20,col='darkblue',xlab='step',ylab='h2',...)
     graphics::abline(v=(nrow(x$step_table)/2-0.5),lty=2)}
-  else if (type=='maxpval'){graphics::plot(x$step_table$step,-log10(x$step_table$maxpval),type='b',lty=2,pch=20,col='darkblue',xlab='step',ylab='-log10(max_Pval)')
+  else if (type=='maxpval'){graphics::plot(x$step_table$step,-log10(x$step_table$maxpval),type='b',lty=2,pch=20,col='darkblue',xlab='step',ylab='-log10(max_Pval)',...)
     graphics::abline(h=x$bonf_thresh,lty=2)
     if(! is.null(x$thresh)){graphics::abline(h=x$thresh,lty=2,col=2)}
     graphics::abline(v=(nrow(x$step_table)/2-0.5),lty=2)}
-  else if (type=='BIC'){graphics::plot(x$step_table$step,x$step_table$BIC,type='b',lty=2,pch=20,col='darkblue',xlab='step',ylab='BIC')
+  else if (type=='BIC'){graphics::plot(x$step_table$step,x$step_table$BIC,type='b',lty=2,pch=20,col='darkblue',xlab='step',ylab='BIC',...)
     graphics::abline(v=(nrow(x$step_table)/2-0.5),lty=2)}
-  else if (type=='extBIC'){graphics::plot(x$step_table$step,x$step_table$extBIC,type='b',lty=2,pch=20,col='darkblue',xlab='step',ylab='EBIC')
+  else if (type=='extBIC'){graphics::plot(x$step_table$step,x$step_table$extBIC,type='b',lty=2,pch=20,col='darkblue',xlab='step',ylab='EBIC',...)
     graphics::abline(v=(nrow(x$step_table)/2-0.5),lty=2)}
   else {cat('error! \n argument type must be one of h2, maxpval, BIC, extBIC')}}
 

--- a/R/plot_mlmm.r
+++ b/R/plot_mlmm.r
@@ -3,65 +3,69 @@
 ##' Plot
 ##' @param x x
 ##' @param type type
+##' @param ... arguments to be passed to \code{\link[graphics]{plot}}, such as \code{main}
 ##' @author V. Segura & B. J. Vilhjalmsson
 ##' @export
-plot_step_table<-function(x,type){
-  if (type=='h2') {plot(x$step_table$step,x$step_table$h2,type='b',lty=2,pch=20,col='darkblue',xlab='step',ylab='h2')
-    abline(v=(nrow(x$step_table)/2-0.5),lty=2)}
-  else if (type=='maxpval'){plot(x$step_table$step,-log10(x$step_table$maxpval),type='b',lty=2,pch=20,col='darkblue',xlab='step',ylab='-log10(max_Pval)')
-    abline(h=x$bonf_thresh,lty=2)
-    if(! is.null(x$thresh)){abline(h=x$thresh,lty=2,col=2)}
-    abline(v=(nrow(x$step_table)/2-0.5),lty=2)}
-  else if (type=='BIC'){plot(x$step_table$step,x$step_table$BIC,type='b',lty=2,pch=20,col='darkblue',xlab='step',ylab='BIC')
-    abline(v=(nrow(x$step_table)/2-0.5),lty=2)}
-  else if (type=='extBIC'){plot(x$step_table$step,x$step_table$extBIC,type='b',lty=2,pch=20,col='darkblue',xlab='step',ylab='EBIC')
-    abline(v=(nrow(x$step_table)/2-0.5),lty=2)}
+plot_step_table<-function(x,type,...){
+  if (type=='h2') {graphics::plot(x$step_table$step,x$step_table$h2,type='b',lty=2,pch=20,col='darkblue',xlab='step',ylab='h2')
+    graphics::abline(v=(nrow(x$step_table)/2-0.5),lty=2)}
+  else if (type=='maxpval'){graphics::plot(x$step_table$step,-log10(x$step_table$maxpval),type='b',lty=2,pch=20,col='darkblue',xlab='step',ylab='-log10(max_Pval)')
+    graphics::abline(h=x$bonf_thresh,lty=2)
+    if(! is.null(x$thresh)){graphics::abline(h=x$thresh,lty=2,col=2)}
+    graphics::abline(v=(nrow(x$step_table)/2-0.5),lty=2)}
+  else if (type=='BIC'){graphics::plot(x$step_table$step,x$step_table$BIC,type='b',lty=2,pch=20,col='darkblue',xlab='step',ylab='BIC')
+    graphics::abline(v=(nrow(x$step_table)/2-0.5),lty=2)}
+  else if (type=='extBIC'){graphics::plot(x$step_table$step,x$step_table$extBIC,type='b',lty=2,pch=20,col='darkblue',xlab='step',ylab='EBIC')
+    graphics::abline(v=(nrow(x$step_table)/2-0.5),lty=2)}
   else {cat('error! \n argument type must be one of h2, maxpval, BIC, extBIC')}}
 
 ##' Plot
 ##'
 ##' Plot
 ##' @param x x
+##' @param ... arguments to be passed to \code{\link[graphics]{plot}}, such as \code{main}
 ##' @author V. Segura & B. J. Vilhjalmsson
 ##' @export
-plot_step_RSS<-function(x){
-  op<-par(mar=c(5, 5, 2, 2))
-  plot(0,0,xlim=c(0,nrow(x$RSSout)-1),ylim=c(0,1),xlab='step',ylab='%var',col=0)
-  polygon(c(0:(nrow(x$RSSout)-1),(nrow(x$RSSout)-1),0), c(x$RSSout[,3],0,0), col='brown1', border=0)
-  polygon(c(0:(nrow(x$RSSout)-1),(nrow(x$RSSout)-1),0), c(x$RSSout[,2],0,0), col='forestgreen', border=0)
-  polygon(c(0:(nrow(x$RSSout)-1),(nrow(x$RSSout)-1),0), c(x$RSSout[,1],0,0), col='dodgerblue4', border=0)
-  abline(v=(nrow(x$step_table)/2-0.5),lty=2)
-  par(op)}
+plot_step_RSS<-function(x,...){
+  op<-graphics::par(mar=c(5, 5, 2, 2))
+  graphics::plot(0,0,xlim=c(0,nrow(x$RSSout)-1),ylim=c(0,1),xlab='step',ylab='%var',col=0,...)
+  graphics::polygon(c(0:(nrow(x$RSSout)-1),(nrow(x$RSSout)-1),0), c(x$RSSout[,3],0,0), col='brown1', border=0)
+  graphics::polygon(c(0:(nrow(x$RSSout)-1),(nrow(x$RSSout)-1),0), c(x$RSSout[,2],0,0), col='forestgreen', border=0)
+  graphics::polygon(c(0:(nrow(x$RSSout)-1),(nrow(x$RSSout)-1),0), c(x$RSSout[,1],0,0), col='dodgerblue4', border=0)
+  graphics::abline(v=(nrow(x$step_table)/2-0.5),lty=2)
+  graphics::par(op)}
 
 ##' Plot
 ##'
 ##' Plot
 ##' @param x x
+##' @param ... arguments to be passed to \code{\link[graphics]{plot}}, such as \code{main}
 ##' @author V. Segura & B. J. Vilhjalmsson
 ##' @export
-plot_step_RSS_cof<-function(x){
-  op<-par(mar=c(5, 5, 2, 2))
-  plot(0,0,xlim=c(0,nrow(x$RSSout)-1),ylim=c(0,1),xlab='step',ylab='%var',col=0)
-  polygon(c(0:(nrow(x$RSSout)-1),(nrow(x$RSSout)-1),0), c(x$RSSout[,4],0,0), col='brown1', border=0)
-  polygon(c(0:(nrow(x$RSSout)-1),(nrow(x$RSSout)-1),0), c(x$RSSout[,3],0,0), col='forestgreen', border=0)
-  polygon(c(0:(nrow(x$RSSout)-1),(nrow(x$RSSout)-1),0), c(x$RSSout[,2],0,0), col='dodgerblue4', border=0)
-  polygon(c(0:(nrow(x$RSSout)-1),(nrow(x$RSSout)-1),0), c(x$RSSout[,1],0,0), col='grey', border=0)
-  abline(v=(nrow(x$step_table)/2-0.5),lty=2)
-  par(op)}
+plot_step_RSS_cof<-function(x,...){
+  op<-graphics::par(mar=c(5, 5, 2, 2))
+  graphics::plot(0,0,xlim=c(0,nrow(x$RSSout)-1),ylim=c(0,1),xlab='step',ylab='%var',col=0,...)
+  graphics::polygon(c(0:(nrow(x$RSSout)-1),(nrow(x$RSSout)-1),0), c(x$RSSout[,4],0,0), col='brown1', border=0)
+  graphics::polygon(c(0:(nrow(x$RSSout)-1),(nrow(x$RSSout)-1),0), c(x$RSSout[,3],0,0), col='forestgreen', border=0)
+  graphics::polygon(c(0:(nrow(x$RSSout)-1),(nrow(x$RSSout)-1),0), c(x$RSSout[,2],0,0), col='dodgerblue4', border=0)
+  graphics::polygon(c(0:(nrow(x$RSSout)-1),(nrow(x$RSSout)-1),0), c(x$RSSout[,1],0,0), col='grey', border=0)
+  graphics::abline(v=(nrow(x$step_table)/2-0.5),lty=2)
+  graphics::par(op)}
 
 ##' Plot
 ##'
 ##' Plot
 ##' @param x x
+##' @param ... arguments to be passed to \code{\link[graphics]{plot}}, such as \code{main}
 ##' @author V. Segura & B. J. Vilhjalmsson
 ##' @export
-plot_GWAS<-function(x) {
+plot_GWAS<-function(x,...) {
   output_<-x$out[order(x$out$Pos),]
   output_ok<-output_[order(output_$Chr),]
-  maxpos<-c(0,cumsum(as.numeric(aggregate(output_ok$Pos,list(output_ok$Chr),max)$x+max(cumsum(as.numeric(aggregate(output_ok$Pos,list(output_ok$Chr),max)$x)))/200)))
+  maxpos<-c(0,cumsum(as.numeric(stats::aggregate(output_ok$Pos,list(output_ok$Chr),max)$x+max(cumsum(as.numeric(stats::aggregate(output_ok$Pos,list(output_ok$Chr),max)$x)))/200)))
   plot_col<-rep(c('gray10','gray60'),ceiling(max(unique(output_ok$Chr))/2))
                                         #	plot_col<-c('blue','darkgreen','red','cyan','purple')
-  size<-aggregate(output_ok$Pos,list(output_ok$Chr),length)$x
+  size<-stats::aggregate(output_ok$Pos,list(output_ok$Chr),length)$x
   a<-rep(maxpos[1],size[1])
   b<-rep(plot_col[1],size[1])
   if (length(unique(output_ok$Chr))>1){
@@ -71,10 +75,10 @@ plot_GWAS<-function(x) {
   output_ok$xpos<-output_ok$Pos+a
   output_ok$col<-b
   output_ok$col[output_ok$SNP %in% x$cof]<-'red'
-  d<-(aggregate(output_ok$xpos,list(output_ok$Chr),min)$x+aggregate(output_ok$xpos,list(output_ok$Chr),max)$x)/2
-  plot(output_ok$xpos,-log10(output_ok$pval),col=output_ok$col,pch=20,ylab=expression(-log[10](italic(p))),xaxt='n',xlab='chromosome')
-  axis(1,tick=FALSE,at=d,labels=unique(output_ok$Chr))
-  abline(h=x$bonf_thresh,lty=3,col='black')}
+  d<-(stats::aggregate(output_ok$xpos,list(output_ok$Chr),min)$x+stats::aggregate(output_ok$xpos,list(output_ok$Chr),max)$x)/2
+  graphics::plot(output_ok$xpos,-log10(output_ok$pval),col=output_ok$col,pch=20,ylab=expression(-log[10](italic(p))),xaxt='n',xlab='chromosome',...)
+  graphics::axis(1,tick=FALSE,at=d,labels=unique(output_ok$Chr))
+  graphics::abline(h=x$bonf_thresh,lty=3,col='black')}
 
 ##' Plot
 ##'
@@ -86,11 +90,12 @@ plot_GWAS<-function(x) {
 ##' @author V. Segura & B. J. Vilhjalmsson
 ##' @export
 plot_region<-function(x,chrom,pos1,pos2){
+  Chr<-Pos<-NULL # to avoid R CMD check issuing a NOTE
   region<-subset(x$out,Chr==chrom & Pos>=pos1 & Pos <=pos2)
   region$col<- if (chrom %% 2 == 0) {'gray60'} else {'gray10'}
   region$col[which(region$SNP %in% x$cof)]<-'red'
-  plot(region$Pos,-log10(region$pval),type='p',pch=20,main=paste('chromosome',chrom,sep=''),xlab='position (bp)',ylab=expression(-log[10](italic(p))),col=region$col,xlim=c(pos1,pos2))
-  abline(h=x$bonf_thresh,lty=3,col='black')}
+  graphics::plot(region$Pos,-log10(region$pval),type='p',pch=20,main=paste('chromosome',chrom,sep=''),xlab='position (bp)',ylab=expression(-log[10](italic(p))),col=region$col,xlim=c(pos1,pos2))
+  graphics::abline(h=x$bonf_thresh,lty=3,col='black')}
 
 ##' Plot
 ##'
@@ -99,12 +104,14 @@ plot_region<-function(x,chrom,pos1,pos2){
 ##' @param step step
 ##' @param snp_info snp_info
 ##' @param pval_filt pval_filt
+##' @param ... arguments to be passed to \code{\link[graphics]{plot}}, such as \code{main}
 ##' @author V. Segura & B. J. Vilhjalmsson
 ##' @export
-plot_fwd_GWAS<-function(x,step,snp_info,pval_filt) {
+plot_fwd_GWAS<-function(x,step,snp_info,pval_filt,...) {
   stopifnot(step<=length(x$pval_step))
+  pval<-NULL # to avoid R CMD check issuing a NOTE
   output<-list(out=subset(merge(snp_info,x$pval_step[[step]]$out,by='SNP'),pval<=pval_filt),cof=x$pval_step[[step]]$cof,bonf_thresh=x$bonf_thresh)
-  plot_GWAS(output)}
+  plot_GWAS(output,...)}
 
 ##' Plot
 ##'
@@ -120,6 +127,7 @@ plot_fwd_GWAS<-function(x,step,snp_info,pval_filt) {
 ##' @export
 plot_fwd_region<-function(x,step,snp_info,pval_filt,chrom,pos1,pos2) {
   stopifnot(step<=length(x$pval_step))
+  pval<-NULL # to avoid R CMD check issuing a NOTE
   output<-list(out=subset(merge(snp_info,x$pval_step[[step]]$out,by='SNP'),pval<=pval_filt),cof=x$pval_step[[step]]$cof,bonf_thresh=x$bonf_thresh)
   plot_region(output,chrom,pos1,pos2)}
 
@@ -130,15 +138,17 @@ plot_fwd_region<-function(x,step,snp_info,pval_filt,chrom,pos1,pos2) {
 ##' @param opt opt
 ##' @param snp_info snp_info
 ##' @param pval_filt pval_filt
+##' @param ... arguments to be passed to \code{\link[graphics]{plot}}, such as \code{main}
 ##' @author V. Segura & B. J. Vilhjalmsson
 ##' @export
-plot_opt_GWAS<-function(x,opt,snp_info,pval_filt) {
+plot_opt_GWAS<-function(x,opt,snp_info,pval_filt,...) {
+  pval<-NULL # to avoid R CMD check issuing a NOTE
   if (opt=='extBIC') {output<-list(out=subset(merge(snp_info,x$opt_extBIC$out,by='SNP'),pval<=pval_filt),cof=x$opt_extBIC$cof,bonf_thresh=x$bonf_thresh)
-  plot_GWAS(output)}
+  plot_GWAS(output,...)}
   else if (opt=='mbonf') {output<-list(out=subset(merge(snp_info,x$opt_mbonf$out,by='SNP'),pval<=pval_filt),cof=x$opt_mbonf$cof,bonf_thresh=x$bonf_thresh)
-  plot_GWAS(output)}
+  plot_GWAS(output,...)}
   else if (opt=='thresh') {output<-list(out=subset(merge(snp_info,x$opt_thresh$out,by='SNP'),pval<=pval_filt),cof=x$opt_thresh$cof,bonf_thresh=x$thresh)
-  plot_GWAS(output)}
+  plot_GWAS(output,...)}
   else {cat('error! \n opt must be extBIC, mbonf or thresh')}}
 
 ##' Plot
@@ -154,6 +164,7 @@ plot_opt_GWAS<-function(x,opt,snp_info,pval_filt) {
 ##' @author V. Segura & B. J. Vilhjalmsson
 ##' @export
 plot_opt_region<-function(x,opt,snp_info,pval_filt,chrom,pos1,pos2) {
+  pval<-NULL # to avoid R CMD check issuing a NOTE
   if (opt=='extBIC') {output<-list(out=subset(merge(snp_info,x$opt_extBIC$out,by='SNP'),pval<=pval_filt),cof=x$opt_extBIC$cof,bonf_thresh=x$bonf_thresh)
   plot_region(output,chrom,pos1,pos2)}
   else if (opt=='mbonf') {output<-list(out=subset(merge(snp_info,x$opt_mbonf$out,by='SNP'),pval<=pval_filt),cof=x$opt_mbonf$cof,bonf_thresh=x$bonf_thresh)
@@ -171,20 +182,20 @@ plot_opt_region<-function(x,opt,snp_info,pval_filt,chrom,pos1,pos2) {
 ##' @export
 qqplot_fwd_GWAS<-function(x,nsteps){
   stopifnot(nsteps<=length(x$pval_step))
-  e<--log10(ppoints(nrow(x$pval_step[[1]]$out)))
+  e<--log10(stats::ppoints(nrow(x$pval_step[[1]]$out)))
   ostep<-list()
   ostep[[1]]<--log10(sort(x$pval_step[[1]]$out$pval))
   for (i in 2:nsteps) {ostep[[i]]<--log10(sort(x$pval_step[[i]]$out$pval))}
 
   maxp<-ceiling(max(unlist(ostep)))
 
-  plot(e,ostep[[1]],type='l',col=1,xlab=expression(Expected~~-log[10](italic(p))), ylab=expression(Observed~~-log[10](italic(p))),xlim=c(0,max(e)+1),ylim=c(0,maxp))
-  abline(0,1,col="dark grey")
+  graphics::plot(e,ostep[[1]],type='l',col=1,xlab=expression(Expected~~-log[10](italic(p))), ylab=expression(Observed~~-log[10](italic(p))),xlim=c(0,max(e)+1),ylim=c(0,maxp))
+  graphics::abline(0,1,col="dark grey")
 
   for (i in 2:nsteps) {
-    par(new=T)
-    plot(e,ostep[[i]],type='l',col=i,axes='F',xlab='',ylab='',xlim=c(0,max(e)+1),ylim=c(0,maxp))}
-  legend(0,maxp,lty=1,pch=20,col=c(1:length(ostep)),paste(c(0:(length(ostep)-1)),'cof',sep=' '))
+    graphics::par(new=T)
+    graphics::plot(e,ostep[[i]],type='l',col=i,axes='F',xlab='',ylab='',xlim=c(0,max(e)+1),ylim=c(0,maxp))}
+  graphics::legend(0,maxp,lty=1,pch=20,col=c(1:length(ostep)),paste(c(0:(length(ostep)-1)),'cof',sep=' '))
 }
 
 ##' Plot
@@ -196,21 +207,21 @@ qqplot_fwd_GWAS<-function(x,nsteps){
 ##' @export
 qqplot_opt_GWAS<-function(x,opt){
   if (opt=='extBIC') {
-    e<--log10(ppoints(nrow(x$opt_extBIC$out)))
+    e<--log10(stats::ppoints(nrow(x$opt_extBIC$out)))
     o<--log10(sort(x$opt_extBIC$out$pval))
     maxp<-ceiling(max(o))
-    plot(e,o,type='l',col=1,xlab=expression(Expected~~-log[10](italic(p))), ylab=expression(Observed~~-log[10](italic(p))),xlim=c(0,max(e)+1),ylim=c(0,maxp),main=paste('optimal model according to extBIC'))
-    abline(0,1,col="dark grey")}
+    graphics::plot(e,o,type='l',col=1,xlab=expression(Expected~~-log[10](italic(p))), ylab=expression(Observed~~-log[10](italic(p))),xlim=c(0,max(e)+1),ylim=c(0,maxp),main=paste('optimal model according to extBIC'))
+    graphics::abline(0,1,col="dark grey")}
   else if (opt=='mbonf') {
-    e<--log10(ppoints(nrow(x$opt_mbonf$out)))
+    e<--log10(stats::ppoints(nrow(x$opt_mbonf$out)))
     o<--log10(sort(x$opt_mbonf$out$pval))
     maxp<-ceiling(max(o))
-    plot(e,o,type='l',col=1,xlab=expression(Expected~~-log[10](italic(p))), ylab=expression(Observed~~-log[10](italic(p))),xlim=c(0,max(e)+1),ylim=c(0,maxp),main=paste('optimal model according to mbonf'))
-    abline(0,1,col="dark grey")}
+    graphics::plot(e,o,type='l',col=1,xlab=expression(Expected~~-log[10](italic(p))), ylab=expression(Observed~~-log[10](italic(p))),xlim=c(0,max(e)+1),ylim=c(0,maxp),main=paste('optimal model according to mbonf'))
+    graphics::abline(0,1,col="dark grey")}
   else if (opt=='thresh') {
-    e<--log10(ppoints(nrow(x$opt_thresh$out)))
+    e<--log10(stats::ppoints(nrow(x$opt_thresh$out)))
     o<--log10(sort(x$opt_thresh$out$pval))
     maxp<-ceiling(max(o))
-    plot(e,o,type='l',col=1,xlab=expression(Expected~~-log[10](italic(p))), ylab=expression(Observed~~-log[10](italic(p))),xlim=c(0,max(e)+1),ylim=c(0,maxp),main=paste('optimal model according to the user defined threshold'))
-    abline(0,1,col="dark grey")}
+    graphics::plot(e,o,type='l',col=1,xlab=expression(Expected~~-log[10](italic(p))), ylab=expression(Observed~~-log[10](italic(p))),xlim=c(0,max(e)+1),ylim=c(0,maxp),main=paste('optimal model according to the user defined threshold'))
+    graphics::abline(0,1,col="dark grey")}
   else {cat('error! \n opt must be extBIC, mbonf or thresh')}}

--- a/man/example_data.Rd
+++ b/man/example_data.Rd
@@ -18,4 +18,3 @@ example_data
 A dataset used as example for the mlmm function.
 }
 \keyword{datasets}
-

--- a/man/mlmm.Rd
+++ b/man/mlmm.Rd
@@ -28,4 +28,3 @@ MLMM
 \author{
 V. Segura & B. J. Vilhjalmsson
 }
-

--- a/man/mlmm_cof.Rd
+++ b/man/mlmm_cof.Rd
@@ -30,4 +30,3 @@ MLMM_COF
 \author{
 V. Segura & B. J. Vilhjalmsson
 }
-

--- a/man/plot_GWAS.Rd
+++ b/man/plot_GWAS.Rd
@@ -4,10 +4,12 @@
 \alias{plot_GWAS}
 \title{Plot}
 \usage{
-plot_GWAS(x)
+plot_GWAS(x, ...)
 }
 \arguments{
 \item{x}{x}
+
+\item{...}{arguments to be passed to \code{\link[graphics]{plot}}, such as \code{main}}
 }
 \description{
 Plot
@@ -15,4 +17,3 @@ Plot
 \author{
 V. Segura & B. J. Vilhjalmsson
 }
-

--- a/man/plot_fwd_GWAS.Rd
+++ b/man/plot_fwd_GWAS.Rd
@@ -4,7 +4,7 @@
 \alias{plot_fwd_GWAS}
 \title{Plot}
 \usage{
-plot_fwd_GWAS(x, step, snp_info, pval_filt)
+plot_fwd_GWAS(x, step, snp_info, pval_filt, ...)
 }
 \arguments{
 \item{x}{x}
@@ -14,6 +14,8 @@ plot_fwd_GWAS(x, step, snp_info, pval_filt)
 \item{snp_info}{snp_info}
 
 \item{pval_filt}{pval_filt}
+
+\item{...}{arguments to be passed to \code{\link[graphics]{plot}}, such as \code{main}}
 }
 \description{
 Plot
@@ -21,4 +23,3 @@ Plot
 \author{
 V. Segura & B. J. Vilhjalmsson
 }
-

--- a/man/plot_fwd_region.Rd
+++ b/man/plot_fwd_region.Rd
@@ -27,4 +27,3 @@ Plot
 \author{
 V. Segura & B. J. Vilhjalmsson
 }
-

--- a/man/plot_opt_GWAS.Rd
+++ b/man/plot_opt_GWAS.Rd
@@ -4,7 +4,7 @@
 \alias{plot_opt_GWAS}
 \title{Plot}
 \usage{
-plot_opt_GWAS(x, opt, snp_info, pval_filt)
+plot_opt_GWAS(x, opt, snp_info, pval_filt, ...)
 }
 \arguments{
 \item{x}{x}
@@ -14,6 +14,8 @@ plot_opt_GWAS(x, opt, snp_info, pval_filt)
 \item{snp_info}{snp_info}
 
 \item{pval_filt}{pval_filt}
+
+\item{...}{arguments to be passed to \code{\link[graphics]{plot}}, such as \code{main}}
 }
 \description{
 Plot
@@ -21,4 +23,3 @@ Plot
 \author{
 V. Segura & B. J. Vilhjalmsson
 }
-

--- a/man/plot_opt_region.Rd
+++ b/man/plot_opt_region.Rd
@@ -27,4 +27,3 @@ Plot
 \author{
 V. Segura & B. J. Vilhjalmsson
 }
-

--- a/man/plot_region.Rd
+++ b/man/plot_region.Rd
@@ -21,4 +21,3 @@ Plot
 \author{
 V. Segura & B. J. Vilhjalmsson
 }
-

--- a/man/plot_step_RSS.Rd
+++ b/man/plot_step_RSS.Rd
@@ -4,10 +4,12 @@
 \alias{plot_step_RSS}
 \title{Plot}
 \usage{
-plot_step_RSS(x)
+plot_step_RSS(x, ...)
 }
 \arguments{
 \item{x}{x}
+
+\item{...}{arguments to be passed to \code{\link[graphics]{plot}}, such as \code{main}}
 }
 \description{
 Plot
@@ -15,4 +17,3 @@ Plot
 \author{
 V. Segura & B. J. Vilhjalmsson
 }
-

--- a/man/plot_step_RSS_cof.Rd
+++ b/man/plot_step_RSS_cof.Rd
@@ -4,10 +4,12 @@
 \alias{plot_step_RSS_cof}
 \title{Plot}
 \usage{
-plot_step_RSS_cof(x)
+plot_step_RSS_cof(x, ...)
 }
 \arguments{
 \item{x}{x}
+
+\item{...}{arguments to be passed to \code{\link[graphics]{plot}}, such as \code{main}}
 }
 \description{
 Plot
@@ -15,4 +17,3 @@ Plot
 \author{
 V. Segura & B. J. Vilhjalmsson
 }
-

--- a/man/plot_step_table.Rd
+++ b/man/plot_step_table.Rd
@@ -4,12 +4,14 @@
 \alias{plot_step_table}
 \title{Plot}
 \usage{
-plot_step_table(x, type)
+plot_step_table(x, type, ...)
 }
 \arguments{
 \item{x}{x}
 
 \item{type}{type}
+
+\item{...}{arguments to be passed to \code{\link[graphics]{plot}}, such as \code{main}}
 }
 \description{
 Plot
@@ -17,4 +19,3 @@ Plot
 \author{
 V. Segura & B. J. Vilhjalmsson
 }
-

--- a/man/qqplot_fwd_GWAS.Rd
+++ b/man/qqplot_fwd_GWAS.Rd
@@ -17,4 +17,3 @@ Plot
 \author{
 V. Segura & B. J. Vilhjalmsson
 }
-

--- a/man/qqplot_opt_GWAS.Rd
+++ b/man/qqplot_opt_GWAS.Rd
@@ -17,4 +17,3 @@ Plot
 \author{
 V. Segura & B. J. Vilhjalmsson
 }
-

--- a/vignettes/mlmm.Rmd
+++ b/vignettes/mlmm.Rmd
@@ -41,9 +41,9 @@ Plot the results:
 plot_step_table(mygwas,'extBIC') # EBIC plot
 plot_step_table(mygwas,'maxpval') # mbonf criterion plot
 plot_step_RSS(mygwas) # % variance plot
-plot_fwd_GWAS(mygwas,1,example_data$snp_info,0.1) # 1st mlmm step plot
-plot_fwd_GWAS(mygwas,2,example_data$snp_info,0.1) # 2nd mlmm step plot
-plot_fwd_GWAS(mygwas,3,example_data$snp_info,0.1) # 3rd mlmm step plot
-plot_opt_GWAS(mygwas,'extBIC',example_data$snp_info,0.1) # optimal step according to eBIC plot
-plot_opt_GWAS(mygwas,'mbonf',example_data$snp_info,0.1) # optimal step according to mbonf plot
+plot_fwd_GWAS(mygwas,1,example_data$snp_info,0.1,main="step 1") # 1st mlmm step plot
+plot_fwd_GWAS(mygwas,2,example_data$snp_info,0.1,main="step 2") # 2nd mlmm step plot
+plot_fwd_GWAS(mygwas,3,example_data$snp_info,0.1,main="step 3") # 3rd mlmm step plot
+plot_opt_GWAS(mygwas,'extBIC',example_data$snp_info,0.1,main="optimal (EBIC)") # optimal step according to eBIC plot
+plot_opt_GWAS(mygwas,'mbonf',example_data$snp_info,0.1,main="optimal (mBonf)") # optimal step according to mbonf plot
 ```


### PR DESCRIPTION
It is quite useful to be able to specify a main title to several of the plotting functions in `mlmm` (as well as other options if necessary). Moreover, the latest version of R requires to specify the default package when using one of their functions, for instance one should call `graphics::plot()`instead of `plot()`. This pull request solves both.